### PR TITLE
Replace Font Awesome icons with lucide-react equivalents

### DIFF
--- a/client/src/components/layout/header.tsx
+++ b/client/src/components/layout/header.tsx
@@ -1,3 +1,5 @@
+import { Bell } from "lucide-react";
+
 interface HeaderProps {
   title: string;
   subtitle?: string;
@@ -14,7 +16,7 @@ export default function Header({ title, subtitle, children }: HeaderProps) {
         </div>
         <div className="flex items-center space-x-4">
           <button className="relative p-2 text-gray-400 hover:text-gray-600 transition-colors">
-            <i className="fas fa-bell text-lg"></i>
+            <Bell className="w-5 h-5" />
             <span className="absolute -top-1 -right-1 w-3 h-3 bg-error-500 rounded-full"></span>
           </button>
           {children}

--- a/client/src/components/upload/file-upload.tsx
+++ b/client/src/components/upload/file-upload.tsx
@@ -3,6 +3,7 @@ import { Button } from "@/components/ui/button";
 import { Progress } from "@/components/ui/progress";
 import { useToast } from "@/hooks/use-toast";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { Loader2, UploadCloud, FolderOpen } from "lucide-react";
 
 interface FileUploadProps {
   onUploadSuccess?: (result: any) => void;
@@ -177,9 +178,9 @@ export default function FileUpload({
         
         <div className="w-16 h-16 bg-gray-100 rounded-xl mx-auto mb-4 flex items-center justify-center">
           {isUploading ? (
-            <i className="fas fa-spinner fa-spin text-gray-600 text-2xl"></i>
+            <Loader2 className="w-8 h-8 text-gray-600 animate-spin" />
           ) : (
-            <i className="fas fa-cloud-upload-alt text-gray-600 text-2xl"></i>
+            <UploadCloud className="w-8 h-8 text-gray-600" />
           )}
         </div>
         
@@ -196,11 +197,11 @@ export default function FileUpload({
             <p className="text-xs text-gray-500">{Math.round(uploadProgress)}% uploaded</p>
           </div>
         ) : (
-          <Button 
+          <Button
             className="bg-primary-500 hover:bg-primary-600 text-white"
             disabled={disabled}
           >
-            <i className="fas fa-folder-open mr-2"></i>
+            <FolderOpen className="w-4 h-4 mr-2" />
             Choose File
           </Button>
         )}

--- a/client/src/pages/classifications.tsx
+++ b/client/src/pages/classifications.tsx
@@ -7,6 +7,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@
 import { useQuery } from "@tanstack/react-query";
 import { useState } from "react";
 import type { PayeeClassification, UploadBatch } from "@/lib/types";
+import { Download, Search, Edit } from "lucide-react";
 
 export default function Classifications() {
   const [searchTerm, setSearchTerm] = useState("");
@@ -68,7 +69,7 @@ export default function Classifications() {
         subtitle="View and manage all payee classifications"
       >
         <Button className="bg-primary-500 hover:bg-primary-600 text-white">
-          <i className="fas fa-download mr-2"></i>
+          <Download className="w-4 h-4 mr-2" />
           Export All
         </Button>
       </Header>
@@ -120,11 +121,11 @@ export default function Classifications() {
             {/* Classifications Table */}
             {filteredClassifications.length === 0 ? (
               <div className="text-center py-12">
-                <i className="fas fa-search text-4xl text-gray-300 mb-4"></i>
+                <Search className="w-10 h-10 text-gray-300 mb-4" />
                 <p className="text-gray-500">No classifications found</p>
                 {searchTerm && (
-                  <Button 
-                    variant="outline" 
+                  <Button
+                    variant="outline"
                     onClick={() => setSearchTerm("")}
                     className="mt-2"
                   >
@@ -228,7 +229,7 @@ export default function Classifications() {
                         </td>
                         <td className="px-6 py-4 whitespace-nowrap text-sm font-medium">
                           <Button variant="outline" size="sm">
-                            <i className="fas fa-edit mr-1"></i>
+                            <Edit className="w-4 h-4 mr-1" />
                             Edit
                           </Button>
                         </td>


### PR DESCRIPTION
## Summary
- replace Font Awesome `<i>` tags with `lucide-react` components in header, file upload, and classifications views
- size and color all icons via Tailwind classes

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run build` (fails: tsconfig.json references tsconfig.node.json which lacks composite)

------
https://chatgpt.com/codex/tasks/task_b_68b74b01edcc83318aa9da88ecefad1c