### PR TITLE
feat: add manual refresh for classifications page

### DIFF
--- a/client/src/pages/classifications.tsx
+++ b/client/src/pages/classifications.tsx
@@ -13,18 +13,29 @@ export default function Classifications() {
   const [selectedBatch, setSelectedBatch] = useState<string>("all");
   const [selectedType, setSelectedType] = useState<string>("all");
 
-  const { data: batches = [] } = useQuery<UploadBatch[]>({
+  const {
+    data: batches = [],
+    refetch: refetchBatches,
+  } = useQuery<UploadBatch[]>({
     queryKey: ["/api/upload/batches"],
-    // Poll every 2 seconds for real-time updates
-    refetchInterval: 2000,
+    refetchOnWindowFocus: true,
   });
 
-  const { data: classifications = [] } = useQuery<PayeeClassification[]>({
-    queryKey: selectedBatch === "all" 
-      ? ["/api/classifications"] 
+  const {
+    data: classifications = [],
+    refetch: refetchClassifications,
+  } = useQuery<PayeeClassification[]>({
+    queryKey: selectedBatch === "all"
+      ? ["/api/classifications"]
       : ["/api/classifications/batch", selectedBatch],
     enabled: selectedBatch !== "all" || batches.length > 0,
+    refetchOnWindowFocus: true,
   });
+
+  const handleRefresh = () => {
+    refetchBatches();
+    refetchClassifications();
+  };
 
   const filteredClassifications = classifications.filter(classification => {
     const matchesSearch = classification.cleanedName.toLowerCase().includes(searchTerm.toLowerCase()) ||
@@ -63,10 +74,14 @@ export default function Classifications() {
 
   return (
     <div className="flex-1 flex flex-col">
-      <Header 
-        title="Classifications" 
+      <Header
+        title="Classifications"
         subtitle="View and manage all payee classifications"
       >
+        <Button variant="outline" onClick={handleRefresh}>
+          <i className="fas fa-sync-alt mr-2"></i>
+          Refresh
+        </Button>
         <Button className="bg-primary-500 hover:bg-primary-600 text-white">
           <i className="fas fa-download mr-2"></i>
           Export All

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -52,6 +52,9 @@ npm run dev
 - **State**: TanStack Query for server state
 - **Build**: Vite for fast development
 
+### Classifications Page Refresh
+The Classifications page no longer polls for updates every two seconds. Use the **Refresh** button in the page header or refocus the browser tab to fetch the latest batches and classifications.
+
 ### Backend Development  
 - **Runtime**: Node.js with Express
 - **Database**: Drizzle ORM with PostgreSQL


### PR DESCRIPTION
## Summary
- stop aggressive polling for upload batches
- add manual Refresh button and window-focus updates on classifications page
- document new refresh workflow

## Testing
- `npm test` (fails: Error: no test specified)


------
https://chatgpt.com/codex/tasks/task_b_68b74b0285388331994da4dfebd8c554