### PR TITLE
Add aria labels for icon-only buttons

### DIFF
--- a/client/src/components/batch-card.tsx
+++ b/client/src/components/batch-card.tsx
@@ -74,7 +74,12 @@ export function BatchCard({ batch, onDelete, onRetry }: BatchCardProps) {
             <StatusPill status={batch.status} />
             <DropdownMenu>
               <DropdownMenuTrigger asChild>
-                <Button variant="ghost" size="icon" className="h-8 w-8">
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="h-8 w-8"
+                  aria-label="Batch options"
+                >
                   <MoreVertical className="h-4 w-4" />
                 </Button>
               </DropdownMenuTrigger>

--- a/client/src/components/classification-viewer.tsx
+++ b/client/src/components/classification-viewer.tsx
@@ -1053,7 +1053,11 @@ export function ClassificationViewer({ batchId, onBack }: ClassificationViewerPr
               
               <Popover>
                 <PopoverTrigger asChild>
-                  <Button variant="outline" size="icon">
+                  <Button
+                    variant="outline"
+                    size="icon"
+                    aria-label="Adjust matching settings"
+                  >
                     <Settings className="h-4 w-4" />
                   </Button>
                 </PopoverTrigger>
@@ -1332,6 +1336,7 @@ export function ClassificationViewer({ batchId, onBack }: ClassificationViewerPr
                             <Button
                               size="sm"
                               variant="ghost"
+                              aria-label="View classification details"
                               onClick={() => {
                                 setSelectedClassification(classification);
                                 fetchPayeeMatches(classification.id);
@@ -1361,6 +1366,7 @@ export function ClassificationViewer({ batchId, onBack }: ClassificationViewerPr
                                       <Button
                                         size="sm"
                                         variant="ghost"
+                                        aria-label="Copy original name"
                                         onClick={() => copyToClipboard(selectedClassification.originalName)}
                                       >
                                         <Copy className="h-3 w-3" />
@@ -1374,6 +1380,7 @@ export function ClassificationViewer({ batchId, onBack }: ClassificationViewerPr
                                       <Button
                                         size="sm"
                                         variant="ghost"
+                                        aria-label="Copy cleaned name"
                                         onClick={() => copyToClipboard(selectedClassification.cleanedName)}
                                       >
                                         <Copy className="h-3 w-3" />
@@ -1953,6 +1960,7 @@ export function ClassificationViewer({ batchId, onBack }: ClassificationViewerPr
                     <Button
                       variant="outline"
                       size="sm"
+                      aria-label="Previous page"
                       onClick={() => setCurrentPage(Math.max(1, currentPage - 1))}
                       disabled={currentPage === 1}
                     >
@@ -1993,6 +2001,7 @@ export function ClassificationViewer({ batchId, onBack }: ClassificationViewerPr
                     <Button
                       variant="outline"
                       size="sm"
+                      aria-label="Next page"
                       onClick={() => setCurrentPage(Math.min(data.pagination?.totalPages || 1, currentPage + 1))}
                       disabled={currentPage === data.pagination?.totalPages}
                     >

--- a/client/src/components/dashboard/review-queue.tsx
+++ b/client/src/components/dashboard/review-queue.tsx
@@ -127,21 +127,26 @@ export default function ReviewQueue() {
                       </div>
                     </td>
                     <td className="px-6 py-4 whitespace-nowrap text-sm font-medium space-x-2">
-                      <button 
+                      <button
+                        aria-label="Approve classification"
                         onClick={() => handleApprove(item)}
                         className="text-success-600 hover:text-success-900"
                         disabled={updateClassificationMutation.isPending}
                       >
                         <i className="fas fa-check"></i>
                       </button>
-                      <button 
+                      <button
+                        aria-label="Reject classification"
                         onClick={() => handleReject(item)}
                         className="text-error-600 hover:text-error-900"
                         disabled={updateClassificationMutation.isPending}
                       >
                         <i className="fas fa-times"></i>
                       </button>
-                      <button className="text-gray-600 hover:text-gray-900">
+                      <button
+                        aria-label="Edit classification"
+                        className="text-gray-600 hover:text-gray-900"
+                      >
                         <i className="fas fa-edit"></i>
                       </button>
                     </td>

--- a/client/src/components/dashboard/upload-widget.tsx
+++ b/client/src/components/dashboard/upload-widget.tsx
@@ -63,7 +63,10 @@ export default function UploadWidget() {
                     </div>
                   </div>
                   {file.status === "completed" && (
-                    <button className="text-gray-400 hover:text-gray-600">
+                    <button
+                      aria-label={`Download ${file.originalFilename}`}
+                      className="text-gray-400 hover:text-gray-600"
+                    >
                       <i className="fas fa-download text-sm"></i>
                     </button>
                   )}

--- a/client/src/components/keyword-manager.tsx
+++ b/client/src/components/keyword-manager.tsx
@@ -443,6 +443,7 @@ export function KeywordManager({ onBack }: KeywordManagerProps = {}) {
                               <Button
                                 variant="outline"
                                 size="sm"
+                                aria-label="Edit keyword"
                                 onClick={() => setEditingKeyword({ ...keyword })}
                               >
                                 <Edit className="h-4 w-4" />
@@ -512,7 +513,11 @@ export function KeywordManager({ onBack }: KeywordManagerProps = {}) {
 
                           <AlertDialog>
                             <AlertDialogTrigger asChild>
-                              <Button variant="outline" size="sm">
+                              <Button
+                                variant="outline"
+                                size="sm"
+                                aria-label="Delete keyword"
+                              >
                                 <Trash2 className="h-4 w-4" />
                               </Button>
                             </AlertDialogTrigger>

--- a/client/src/components/layout/header.tsx
+++ b/client/src/components/layout/header.tsx
@@ -13,7 +13,10 @@ export default function Header({ title, subtitle, children }: HeaderProps) {
           {subtitle && <p className="text-sm text-gray-500 mt-1">{subtitle}</p>}
         </div>
         <div className="flex items-center space-x-4">
-          <button className="relative p-2 text-gray-400 hover:text-gray-600 transition-colors">
+          <button
+            aria-label="Notifications"
+            className="relative p-2 text-gray-400 hover:text-gray-600 transition-colors"
+          >
             <i className="fas fa-bell text-lg"></i>
             <span className="absolute -top-1 -right-1 w-3 h-3 bg-error-500 rounded-full"></span>
           </button>

--- a/client/src/components/review/review-item.tsx
+++ b/client/src/components/review/review-item.tsx
@@ -150,6 +150,7 @@ export default function ReviewItem({
           <Button
             size="sm"
             variant="ghost"
+            aria-label="Approve classification"
             onClick={() => handleQuickAction("approve")}
             disabled={updateMutation.isPending}
             className="text-success-600 hover:text-success-700 hover:bg-success-50"
@@ -159,6 +160,7 @@ export default function ReviewItem({
           <Button
             size="sm"
             variant="ghost"
+            aria-label="Reject classification"
             onClick={() => handleQuickAction("reject")}
             disabled={updateMutation.isPending}
             className="text-error-600 hover:text-error-700 hover:bg-error-50"
@@ -168,6 +170,7 @@ export default function ReviewItem({
           <Button
             size="sm"
             variant="ghost"
+            aria-label="Edit classification"
             onClick={() => handleQuickAction("edit")}
             disabled={updateMutation.isPending}
             className="text-gray-600 hover:text-gray-700 hover:bg-gray-50"

--- a/client/src/components/ui/progress-tracker.tsx
+++ b/client/src/components/ui/progress-tracker.tsx
@@ -118,6 +118,7 @@ export default function ProgressTracker({ batch, onCancel, onDelete }: ProgressT
               <Button
                 variant="outline"
                 size="sm"
+                aria-label="Cancel batch"
                 onClick={() => {
                   cancelMutation.mutate(batch.id);
                   if (onCancel) onCancel();
@@ -130,6 +131,7 @@ export default function ProgressTracker({ batch, onCancel, onDelete }: ProgressT
             <Button
               variant="outline"
               size="sm"
+              aria-label="Delete batch"
               onClick={() => {
                 deleteMutation.mutate(batch.id);
                 if (onDelete) onDelete();


### PR DESCRIPTION
## Summary
- improve accessibility by labeling notification bell and various icon-only buttons
- add aria labels for classification controls, batch options, and keyword management actions
- ensure pagination and progress tracker icons have screen-reader text

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run build` (fails: tsconfig.json must have setting "composite": true)


------
https://chatgpt.com/codex/tasks/task_b_68b74b0327f88331a71e3b6b2b0fcf60