### PR TITLE
Add global error boundary with fallback UI

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -5,7 +5,10 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1" />
   </head>
   <body>
-    <div id="root"></div>
+    <div id="root">
+      <noscript>You need to enable JavaScript to run this app.</noscript>
+      <div style="padding:1rem;font-family:sans-serif">Loading...</div>
+    </div>
     <script type="module" src="/src/main.tsx"></script>
     <!-- This is a replit script which adds a banner on the top of the page when opened in development mode outside the replit environment -->
     <script type="text/javascript" src="https://replit.com/public/js/replit-dev-banner.js"></script>

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -3,6 +3,7 @@ import { queryClient } from "./lib/queryClient";
 import { QueryClientProvider } from "@tanstack/react-query";
 import { Toaster } from "@/components/ui/toaster";
 import { TooltipProvider } from "@/components/ui/tooltip";
+import ErrorBoundary from "@/components/layout/ErrorBoundary";
 import Dashboard from "@/pages/dashboard";
 import Upload from "@/pages/upload";
 import KeywordManagerPage from "@/pages/keyword-manager";
@@ -34,7 +35,9 @@ function App() {
     <QueryClientProvider client={queryClient}>
       <TooltipProvider>
         <Toaster />
-        <Router />
+        <ErrorBoundary>
+          <Router />
+        </ErrorBoundary>
       </TooltipProvider>
     </QueryClientProvider>
   );

--- a/client/src/components/layout/ErrorBoundary.tsx
+++ b/client/src/components/layout/ErrorBoundary.tsx
@@ -1,0 +1,73 @@
+import { Component, ErrorInfo, ReactNode } from "react";
+
+interface ErrorBoundaryProps {
+  children: ReactNode;
+}
+
+interface ErrorBoundaryState {
+  hasError: boolean;
+}
+
+export default class ErrorBoundary extends Component<
+  ErrorBoundaryProps,
+  ErrorBoundaryState
+> {
+  constructor(props: ErrorBoundaryProps) {
+    super(props);
+    this.state = { hasError: false };
+  }
+
+  static getDerivedStateFromError(): ErrorBoundaryState {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo) {
+    console.error("ErrorBoundary caught an error", error, info);
+    // Attempt to report the error to a remote service for diagnostics
+    try {
+      if (typeof fetch !== "undefined") {
+        fetch("/api/log-client-error", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ error: error.message, info }),
+          keepalive: true,
+        });
+      }
+    } catch (reportError) {
+      console.error("Failed to report error", reportError);
+    }
+  }
+
+  private handleRestart = () => {
+    this.setState({ hasError: false });
+    window.location.reload();
+  };
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <div className="min-h-screen flex flex-col items-center justify-center p-4 text-center space-y-4">
+          <h1 className="text-2xl font-semibold">Something went wrong</h1>
+          <p>Please try reloading the page or report the issue.</p>
+          <div className="flex space-x-4">
+            <button
+              onClick={this.handleRestart}
+              className="px-4 py-2 bg-primary-500 text-white rounded"
+            >
+              Reload
+            </button>
+            <a
+              href="mailto:support@example.com"
+              className="px-4 py-2 border rounded"
+            >
+              Send Feedback
+            </a>
+          </div>
+        </div>
+      );
+    }
+
+    return this.props.children;
+  }
+}
+


### PR DESCRIPTION
## Summary
- add reusable ErrorBoundary component that logs errors and offers reload/feedback options
- wrap application router with ErrorBoundary
- include HTML fallback skeleton when React fails to load

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run build` *(fails: Referenced project must have setting "composite": true)*

------
https://chatgpt.com/codex/tasks/task_b_68b74dba40a08331a207f259af466469