### PR TITLE
feat: accessible sidebar navigation with icons

### DIFF
--- a/client/src/components/layout/sidebar.tsx
+++ b/client/src/components/layout/sidebar.tsx
@@ -1,17 +1,44 @@
-import { Link, useLocation } from "wouter";
+import { Link as NavLink, useLocation } from "wouter";
 import { cn } from "@/lib/utils";
+import {
+  LayoutDashboard,
+  Upload,
+  FileCheck,
+  Tags,
+  List,
+  Download,
+} from "lucide-react";
+import { useRef } from "react";
 
 const navigation = [
-  { name: "Dashboard", href: "/" },
-  { name: "Upload", href: "/upload" },
-  { name: "Single Classification", href: "/single" },
-  { name: "Keyword Manager", href: "/keywords" },
-  { name: "Classifications", href: "/classifications" },
-  { name: "Downloads", href: "/downloads" },
+  { name: "Dashboard", href: "/", icon: LayoutDashboard },
+  { name: "Upload", href: "/upload", icon: Upload },
+  { name: "Single Classification", href: "/single", icon: FileCheck },
+  { name: "Keyword Manager", href: "/keywords", icon: Tags },
+  { name: "Classifications", href: "/classifications", icon: List },
+  { name: "Downloads", href: "/downloads", icon: Download },
 ];
 
 export default function Sidebar() {
-  const [location] = useLocation();
+  const [location, setLocation] = useLocation();
+  const itemRefs = useRef<(HTMLAnchorElement | null)[]>([]);
+
+  const handleKeyDown = (index: number) => (
+    e: React.KeyboardEvent<HTMLAnchorElement>
+  ) => {
+    if (e.key === "ArrowDown") {
+      e.preventDefault();
+      const next = (index + 1) % navigation.length;
+      itemRefs.current[next]?.focus();
+    } else if (e.key === "ArrowUp") {
+      e.preventDefault();
+      const prev = (index - 1 + navigation.length) % navigation.length;
+      itemRefs.current[prev]?.focus();
+    } else if (e.key === "Enter") {
+      e.preventDefault();
+      setLocation(navigation[index].href);
+    }
+  };
 
   return (
     <div className="w-48 bg-white border-r flex flex-col">
@@ -25,20 +52,28 @@ export default function Sidebar() {
 
       {/* Navigation */}
       <nav className="flex-1 p-4 space-y-1">
-        {navigation.map((item) => (
-          <Link key={item.name} href={item.href}>
-            <div
+        {navigation.map((item, idx) => {
+          const Icon = item.icon;
+          const active = location === item.href;
+          return (
+            <NavLink
+              key={item.name}
+              href={item.href}
+              aria-label={item.name}
               className={cn(
-                "px-3 py-2 rounded text-sm cursor-pointer",
-                location === item.href
-                  ? "bg-blue-50 text-blue-700"
-                  : "text-gray-600 hover:bg-gray-50",
+                "flex items-center gap-2 px-3 py-2 rounded text-sm outline-none focus-visible:ring-2 focus-visible:ring-primary-600",
+                active
+                  ? "bg-primary-50 text-primary-700"
+                  : "text-gray-600 hover:bg-gray-50 hover:text-gray-900"
               )}
+              ref={(el) => (itemRefs.current[idx] = el)}
+              onKeyDown={handleKeyDown(idx)}
             >
-              {item.name}
-            </div>
-          </Link>
-        ))}
+              <Icon className="h-4 w-4" aria-hidden="true" />
+              <span>{item.name}</span>
+            </NavLink>
+          );
+        })}
       </nav>
     </div>
   );


### PR DESCRIPTION
## Summary
- replace div-based links with accessible NavLink elements
- add lucide icons and active route styling
- support keyboard navigation for sidebar items

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run build` (fails: Referenced project tsconfig.node.json must have setting "composite": true)

------
https://chatgpt.com/codex/tasks/task_b_68b74db8645c83319929b02fd45222b1