### PR TITLE
Refactor app into reusable layout with sidebar and header

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -3,6 +3,7 @@ import { queryClient } from "./lib/queryClient";
 import { QueryClientProvider } from "@tanstack/react-query";
 import { Toaster } from "@/components/ui/toaster";
 import { TooltipProvider } from "@/components/ui/tooltip";
+import Layout from "@/components/layout/Layout";
 import Dashboard from "@/pages/dashboard";
 import Upload from "@/pages/upload";
 import KeywordManagerPage from "@/pages/keyword-manager";
@@ -14,7 +15,7 @@ import { BatchJobMonitor } from "@/pages/batch-job-monitor";
 
 function Router() {
   return (
-    <div className="min-h-screen bg-gradient-to-br from-gray-50 to-gray-100 dark:from-gray-900 dark:to-gray-950 transition-colors duration-300">
+    <Layout>
       <Switch>
         <Route path="/" component={Dashboard} />
         <Route path="/upload" component={Upload} />
@@ -25,7 +26,7 @@ function Router() {
         <Route path="/batch-jobs" component={BatchJobMonitor} />
         <Route component={NotFound} />
       </Switch>
-    </div>
+    </Layout>
   );
 }
 

--- a/client/src/components/layout/Layout.tsx
+++ b/client/src/components/layout/Layout.tsx
@@ -1,0 +1,61 @@
+import { useLocation } from "wouter";
+import Sidebar from "@/components/layout/sidebar";
+import Header from "@/components/layout/header";
+import React from "react";
+
+const headers: Record<string, { title: string; subtitle?: string }> = {
+  "/": {
+    title: "Dashboard",
+    subtitle: "Overview of classification activity",
+  },
+  "/upload": {
+    title: "Upload Data",
+    subtitle:
+      "Upload CSV or Excel files for high-accuracy OpenAI classification (95%+ confidence only)",
+  },
+  "/keywords": {
+    title: "Keyword Manager",
+    subtitle: "Manage exclusion keywords",
+  },
+  "/single": {
+    title: "Single Classification",
+    subtitle: "Classify a single payee",
+  },
+  "/classifications": {
+    title: "Classifications",
+    subtitle: "View and manage all payee classifications",
+  },
+  "/downloads": {
+    title: "Downloads",
+    subtitle: "Download completed classification results",
+  },
+  "/batch-jobs": {
+    title: "Batch Jobs",
+    subtitle: "Monitor processing jobs",
+  },
+};
+
+interface LayoutProps {
+  children: React.ReactNode;
+}
+
+export default function Layout({ children }: LayoutProps) {
+  const [location] = useLocation();
+  const header = headers[location] || { title: "" };
+
+  return (
+    <div className="min-h-screen flex bg-gradient-to-br from-gray-50 to-gray-100 dark:from-gray-900 dark:to-gray-950 transition-colors duration-300">
+      {/* Sidebar */}
+      <div className="hidden md:flex">
+        <Sidebar />
+      </div>
+
+      {/* Main content */}
+      <div className="flex-1 flex flex-col">
+        <Header title={header.title} subtitle={header.subtitle} />
+        <main className="flex-1 p-6 overflow-auto">{children}</main>
+      </div>
+    </div>
+  );
+}
+

--- a/client/src/pages/classifications.tsx
+++ b/client/src/pages/classifications.tsx
@@ -1,4 +1,3 @@
-import Header from "@/components/layout/header";
 import { Card, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
@@ -74,11 +73,8 @@ export default function Classifications() {
   };
 
   return (
-    <div className="flex-1 flex flex-col">
-      <Header
-        title="Classifications"
-        subtitle="View and manage all payee classifications"
-      >
+    <div className="space-y-6">
+      <div className="flex justify-end gap-2">
         <Button variant="outline" onClick={handleRefresh}>
           <i className="fas fa-sync-alt mr-2"></i>
           Refresh
@@ -87,13 +83,11 @@ export default function Classifications() {
           <Download className="w-4 h-4 mr-2" />
           Export All
         </Button>
-      </Header>
-
-      <main className="flex-1 p-6 overflow-auto">
-        <Card className="shadow-sm">
-          <CardContent className="p-6">
-            {/* Filters */}
-            <div className="flex flex-col sm:flex-row gap-4 mb-6">
+      </div>
+      <Card className="shadow-sm">
+        <CardContent className="p-6">
+          {/* Filters */}
+          <div className="flex flex-col sm:flex-row gap-4 mb-6">
               <div className="flex-1">
                 <Input
                   placeholder="Search payees..."
@@ -256,7 +250,6 @@ export default function Classifications() {
             )}
           </CardContent>
         </Card>
-      </main>
     </div>
   );
 }

--- a/client/src/pages/dashboard.tsx
+++ b/client/src/pages/dashboard.tsx
@@ -1,4 +1,3 @@
-import Header from "@/components/layout/header";
 import KpiCards from "@/components/dashboard/kpi-cards";
 import ClassificationChart from "@/components/dashboard/classification-chart";
 import UploadWidget from "@/components/dashboard/upload-widget";
@@ -22,17 +21,14 @@ export default function Dashboard() {
   const activities: ActivityItem[] = [];
 
   return (
-    <div className="flex-1 flex flex-col">
-      <Header title="Dashboard" subtitle="Overview of classification activity" />
-      <main className="flex-1 p-6 overflow-auto space-y-6">
-        {stats && <KpiCards stats={stats} />}
-        <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
-          <ClassificationChart data={chartData} />
-          <UploadWidget />
-        </div>
-        <BusinessInsights categories={categories} activities={activities} />
-        <ReviewQueue />
-      </main>
+    <div className="space-y-6">
+      {stats && <KpiCards stats={stats} />}
+      <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
+        <ClassificationChart data={chartData} />
+        <UploadWidget />
+      </div>
+      <BusinessInsights categories={categories} activities={activities} />
+      <ReviewQueue />
     </div>
   );
 }

--- a/client/src/pages/downloads.tsx
+++ b/client/src/pages/downloads.tsx
@@ -1,6 +1,5 @@
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { Button } from "@/components/ui/button";
-import Header from "@/components/layout/header";
 import { UploadBatch } from "@/lib/types";
 import { useToast } from "@/hooks/use-toast";
 import { Trash2 } from "lucide-react";
@@ -84,79 +83,64 @@ export default function Downloads() {
 
   if (isLoading) {
     return (
-      <div className="flex-1 flex items-center justify-center">
+      <div className="flex items-center justify-center h-full">
         <p>Loading downloads...</p>
       </div>
     );
   }
 
   return (
-    <div className="flex-1 flex flex-col">
-      <Header 
-        title="Downloads" 
-        subtitle="Download completed classification results"
-      >
-        {completedBatches.length > 0 && (
-          <Button
-            variant="outline"
-            onClick={() => clearAllMutation.mutate()}
-            disabled={clearAllMutation.isPending}
-            className="text-red-600 hover:text-red-700"
-          >
-            <Trash2 className="h-4 w-4 mr-2" />
-            Clear All
-          </Button>
-        )}
-      </Header>
-
-      <main className="flex-1 p-6 overflow-auto">
-        <div className="max-w-4xl mx-auto">
-          {completedBatches.length === 0 ? (
-            <div className="text-center py-12">
-              <div className="text-gray-500 mb-4">No completed jobs available for download</div>
-              <p className="text-sm text-gray-400">Upload and process files to see download options here</p>
-            </div>
-          ) : (
-            <div className="space-y-4">
-              <div className="text-sm text-gray-600 mb-6">
-                {completedBatches.length} completed job{completedBatches.length !== 1 ? 's' : ''} ready for download
-              </div>
-              
-              {completedBatches.map((batch) => (
-                <div key={batch.id} className="border rounded-lg p-4 flex items-center justify-between">
-                  <div className="flex-1">
-                    <div className="font-medium">{batch.originalFilename}</div>
-                    <div className="text-sm text-gray-500">
-                      {batch.processedRecords} records processed • {Math.round((batch.accuracy || 0) * 100)}% accuracy
-                    </div>
-                    <div className="text-xs text-gray-400">
-                      Completed on {new Date(batch.completedAt || batch.createdAt).toLocaleDateString()}
-                    </div>
-                  </div>
-                  
-                  <div className="flex gap-2">
-                    <Button 
-                      onClick={() => handleDownload(batch.id, batch.originalFilename)}
-                      size="sm"
-                    >
-                      Download CSV
-                    </Button>
-                    <Button 
-                      variant="outline"
-                      size="sm"
-                      onClick={() => deleteMutation.mutate(batch.id)}
-                      disabled={deleteMutation.isPending}
-                      className="text-red-600 hover:text-red-700"
-                    >
-                      <Trash2 className="h-4 w-4" />
-                    </Button>
-                  </div>
-                </div>
-              ))}
-            </div>
-          )}
+    <div className="max-w-4xl mx-auto space-y-4">
+      {completedBatches.length === 0 ? (
+        <div className="text-center py-12">
+          <div className="text-gray-500 mb-4">No completed jobs available for download</div>
+          <p className="text-sm text-gray-400">Upload and process files to see download options here</p>
         </div>
-      </main>
+      ) : (
+        <>
+          <div className="flex justify-end">
+            <Button
+              variant="outline"
+              onClick={() => clearAllMutation.mutate()}
+              disabled={clearAllMutation.isPending}
+              className="text-red-600 hover:text-red-700"
+            >
+              <Trash2 className="h-4 w-4 mr-2" />
+              Clear All
+            </Button>
+          </div>
+          <div className="text-sm text-gray-600 mb-6">
+            {completedBatches.length} completed job{completedBatches.length !== 1 ? 's' : ''} ready for download
+          </div>
+          {completedBatches.map((batch) => (
+            <div key={batch.id} className="border rounded-lg p-4 flex items-center justify-between">
+              <div className="flex-1">
+                <div className="font-medium">{batch.originalFilename}</div>
+                <div className="text-sm text-gray-500">
+                  {batch.processedRecords} records processed • {Math.round((batch.accuracy || 0) * 100)}% accuracy
+                </div>
+                <div className="text-xs text-gray-400">
+                  Completed on {new Date(batch.completedAt || batch.createdAt).toLocaleDateString()}
+                </div>
+              </div>
+              <div className="flex gap-2">
+                <Button onClick={() => handleDownload(batch.id, batch.originalFilename)} size="sm">
+                  Download CSV
+                </Button>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => deleteMutation.mutate(batch.id)}
+                  disabled={deleteMutation.isPending}
+                  className="text-red-600 hover:text-red-700"
+                >
+                  <Trash2 className="h-4 w-4" />
+                </Button>
+              </div>
+            </div>
+          ))}
+        </>
+      )}
     </div>
   );
 }

--- a/client/src/pages/keyword-manager.tsx
+++ b/client/src/pages/keyword-manager.tsx
@@ -1,13 +1,5 @@
-import Header from "@/components/layout/header";
 import { KeywordManager } from "@/components/keyword-manager";
 
 export default function KeywordManagerPage() {
-  return (
-    <div className="flex-1 flex flex-col">
-      <Header title="Keyword Manager" subtitle="Manage exclusion keywords" />
-      <main className="flex-1 p-6 overflow-auto">
-        <KeywordManager />
-      </main>
-    </div>
-  );
+  return <KeywordManager />;
 }

--- a/client/src/pages/single-classification.tsx
+++ b/client/src/pages/single-classification.tsx
@@ -1,13 +1,5 @@
-import Header from "@/components/layout/header";
 import { SingleClassification } from "@/components/single-classification";
 
 export default function SingleClassificationPage() {
-  return (
-    <div className="flex-1 flex flex-col">
-      <Header title="Single Classification" subtitle="Classify a single payee" />
-      <main className="flex-1 p-6 overflow-auto">
-        <SingleClassification />
-      </main>
-    </div>
-  );
+  return <SingleClassification />;
 }

--- a/client/src/pages/upload.tsx
+++ b/client/src/pages/upload.tsx
@@ -1,4 +1,3 @@
-import Header from "@/components/layout/header";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Progress } from "@/components/ui/progress";
@@ -209,11 +208,7 @@ export default function Upload() {
   };
 
   return (
-    <div className="flex-1 flex flex-col">
-      <Header title="Upload Data" subtitle="Upload CSV or Excel files for high-accuracy OpenAI classification (95%+ confidence only)" />
-
-      <main className="flex-1 p-6 overflow-auto">
-        <div className="max-w-6xl mx-auto space-y-6">
+    <div className="max-w-6xl mx-auto space-y-6">
 
 
           <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
@@ -435,8 +430,6 @@ export default function Upload() {
               </div>
             </div>
           </div>
-        </div>
-      </main>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add Layout component to compose sidebar, header and routed content
- wrap Router with new Layout and simplify page components
- collapse sidebar on small screens using Tailwind

## Testing
- `npm run build` *(fails: Referenced project tsconfig.node.json must have setting "composite": true)*
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_b_68b74db9d00c83318ad43774ea8b22a7